### PR TITLE
Set up Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,27 @@ sudo: false
 
 matrix:
   include:
-    - rust: 1.32.0
-      os: linux
-      name: "Linux, 1.32.0"
+    # - rust: 1.32.0
+    #   os: linux
+    #   name: "Linux, 1.32.0"
 
     - rust: stable
       os: linux
       name: "Linux, stable"
 
-    - rust: stable
-      os: osx
-      name: "OSX+iOS, stable"
-      env: TARGET=x86_64-apple-darwin
-      install:
-        - rustup target add aarch64-apple-ios
-      script:
-        - bash ci/script.sh
-        - cargo build --target=aarch64-apple-ios
+    # - rust: stable
+    #   os: osx
+    #   name: "OSX+iOS, stable"
+    #   env: TARGET=x86_64-apple-darwin
+    #   install:
+    #     - rustup target add aarch64-apple-ios
+    #   script:
+    #     - bash ci/script.sh
+    #     - cargo build --target=aarch64-apple-ios
 
-    - rust: nightly
-      os: linux
-      name: "Linux, nightly"
+    # - rust: nightly
+    #   os: linux
+    #   name: "Linux, nightly"
 
 before_install:
   - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,49 @@
+language: rust
+sudo: false
+
+# Since most OS-specific code has moved to the getrandom crate, we require
+# few target-specific tests here.
+
+matrix:
+  include:
+    - rust: 1.32.0
+      name: "Linux, 1.32.0"
+      os: linux
+
+    - rust: stable
+      name: "Linux, stable"
+
+    - rust: stable
+      name: "OSX+iOS, stable"
+      os: osx
+      install:
+        - rustup target add aarch64-apple-ios
+      script:
+        - bash utils/ci/script.sh
+        - cargo build --target=aarch64-apple-ios
+
+    - rust: nightly
+      os: linux
+      name: "Linux, nightly"
+
+before_install:
+  - set -e
+  - rustup self update
+
+install:
+  - sh ci/install.sh
+  - source ~/.cargo/env || true
+
+script:
+  - bash ci/script.sh
+
+after_script: set +e
+
+cache: cargo
+before_cache:
+  # Travis can't cache files that are not readable by "others"
+  - chmod -R a+r $HOME/.cargo
+
+notifications:
+  email:
+    on_success: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
       install:
         - rustup target add aarch64-apple-ios
       script:
-        - bash utils/ci/script.sh
+        - bash ci/script.sh
         - cargo build --target=aarch64-apple-ios
 
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,17 @@ sudo: false
 matrix:
   include:
     - rust: 1.32.0
-      name: "Linux, 1.32.0"
       os: linux
+      name: "Linux, 1.32.0"
 
     - rust: stable
+      os: linux
       name: "Linux, stable"
 
     - rust: stable
-      name: "OSX+iOS, stable"
       os: osx
+      name: "OSX+iOS, stable"
+      env: TARGET=x86_64-apple-darwin
       install:
         - rustup target add aarch64-apple-ios
       script:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Status](https://travis-ci.org/haplo/rust-bch.png?branch=master)](https://travis-ci.org/haplo/rust-bch)
+
 # Rust-BCH
 
 A library to build Bitcoin Cash (BCH) applications in Rust.

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,48 @@
+# https://github.com/japaric/trust/blob/master/ci/install.sh
+set -ex
+
+main() {
+    local target=
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        target=x86_64-unknown-linux-musl
+        sort=sort
+    else
+        target=x86_64-apple-darwin
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
+    fi
+
+    # Builds for iOS are done on OSX, but require the specific target to be
+    # installed.
+    case $TARGET in
+        aarch64-apple-ios)
+            rustup target install aarch64-apple-ios
+            ;;
+        armv7-apple-ios)
+            rustup target install armv7-apple-ios
+            ;;
+        armv7s-apple-ios)
+            rustup target install armv7s-apple-ios
+            ;;
+        i386-apple-ios)
+            rustup target install i386-apple-ios
+            ;;
+        x86_64-apple-ios)
+            rustup target install x86_64-apple-ios
+            ;;
+    esac
+
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0.1.0-9.]+$' \
+                       | $sort --version-sort \
+                       | tail -n1)
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag $tag \
+           --target $target
+}
+
+main

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,16 +3,39 @@
 
 set -ex
 
+# ----- Options -----
+
+# TARGET enables cross-building
+if [ -z $TARGET ]; then
+    CARGO=cargo
+elif [ "$TARGET" = "i686-unknown-linux-musl" ]; then
+    CARGO=cargo
+    TARGET="--target $TARGET"
+else
+    CARGO=cross
+    TARGET="--target $TARGET"
+fi
+
+# ALLOC defaults on; is disabled for rustc < 1.36
+if [ -z $ALLOC ]; then
+    ALLOC=1
+fi
+
+# NIGHTLY defaults off
+
+
+# ----- Script -----
+
 main() {
-    cross build --target $TARGET
-    cross build --target $TARGET --release
+    $CARGO build $TARGET
+    $CARGO build $TARGET --release
 
     if [ ! -z $DISABLE_TESTS ]; then
         return
     fi
 
-    cross test --target $TARGET
-    cross test --target $TARGET --release
+    $CARGO test $TARGET
+    $CARGO test $TARGET --release
 }
 
 # we don't run the "test phase" when doing deploys

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,21 @@
+# This script takes care of testing your crate
+# https://github.com/japaric/trust/blob/master/ci/script.sh
+
+set -ex
+
+main() {
+    cross build --target $TARGET
+    cross build --target $TARGET --release
+
+    if [ ! -z $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cross test --target $TARGET
+    cross test --target $TARGET --release
+}
+
+# we don't run the "test phase" when doing deploys
+if [ -z $TRAVIS_TAG ]; then
+    main
+fi


### PR DESCRIPTION
The goal is to support multiple targets (MacOS, rust 1.32, rust nightly...) but they fail with the current configuration for different reasons. They are disabled for now, can be fixed at a later time.

Fixes #1.